### PR TITLE
Improve DB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # bgc-atlas-analysis
 
 [![DOI](https://zenodo.org/badge/842929533.svg)](https://doi.org/10.5281/zenodo.13903803)
+
+## Database Configuration
+
+`Database.java` reads the connection URL, user and password from environment
+variables. Set the following variables before running the application:
+
+```
+export DB_URL="jdbc:postgresql://localhost:5432/atlas"
+export DB_USER="myuser"
+export DB_PASSWORD="secret"
+```
+
+If these variables are not present, the class looks for a `db.properties`
+file in the working directory with the keys `db.url`, `db.user` and
+`db.password`.

--- a/src/dbutil/Database.java
+++ b/src/dbutil/Database.java
@@ -10,26 +10,44 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 public class Database {
 
-    private final String url = "jdbc:postgresql://localhost:5432/atlas";
-    private final String user = "user";
-    private final String password = "password";
+    private String url;
+    private String user;
+    private String password;
 
     private final Connection connection;
 
     public Database() {
+        loadConfiguration();
         this.connection = this.connect();
     }
 
     public Database(boolean connect) {
+        loadConfiguration();
         if(!connect) {
             this.connection = null;
             return;
         } else {
             this.connection = this.connect();
         }
+    }
+
+    private void loadConfiguration() {
+        Properties props = new Properties();
+        try(InputStream in = new FileInputStream("db.properties")) {
+            props.load(in);
+        } catch (IOException ignored) {}
+
+        Map<String, String> env = System.getenv();
+        this.url = env.getOrDefault("DB_URL", props.getProperty("db.url", "jdbc:postgresql://localhost:5432/atlas"));
+        this.user = env.getOrDefault("DB_USER", props.getProperty("db.user", "user"));
+        this.password = env.getOrDefault("DB_PASSWORD", props.getProperty("db.password", "password"));
     }
 
     private Connection connect() {


### PR DESCRIPTION
## Summary
- allow `Database.java` to read credentials from environment variables or `db.properties`
- document new DB configuration in README

## Testing
- `javac -d build src/dbutil/Database.java src/jsonutil/JsonUtil.java` *(fails: package dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68485241eaa48333a31dca75235b7676