### PR TITLE
Refactor DB utils for safer resource handling

### DIFF
--- a/src/dbutil/ResultSetHandler.java
+++ b/src/dbutil/ResultSetHandler.java
@@ -1,0 +1,9 @@
+package dbutil;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface ResultSetHandler<T> {
+    T handle(ResultSet rs) throws SQLException;
+}

--- a/src/pipeline/mgnify/CreateGCFTable.java
+++ b/src/pipeline/mgnify/CreateGCFTable.java
@@ -27,9 +27,16 @@ public class CreateGCFTable {
 
             BufferedWriter bw = new BufferedWriter(new FileWriter(new File(gcfTable)));
 
-            ResultSet gcfIDs = database.executeQuery("SELECT DISTINCT(gcf_id) FROM bigslice_gcf_membership");
-            while(gcfIDs.next()) {
-                int gcfId = gcfIDs.getInt(1);
+            List<Integer> gcfIDs = database.executeQuery(
+                    "SELECT DISTINCT(gcf_id) FROM bigslice_gcf_membership",
+                    rs -> {
+                        List<Integer> ids = new ArrayList<>();
+                        while (rs.next()) {
+                            ids.add(rs.getInt(1));
+                        }
+                        return ids;
+                    });
+            for (int gcfId : gcfIDs) {
 
                 int regCount = 0;
                 Map<String, Integer> productCount = new HashMap<>();
@@ -50,12 +57,16 @@ public class CreateGCFTable {
                         }
                     }
 
-                    ResultSet longestBiome = database.executeQuery("SELECT longest_biome FROM assembly2longestbiome WHERE assembly = '" + assembly + "'");
-                    if(longestBiome.next()) {
-                        String longestBiomeString = longestBiome.getString(1);
-                        biomeCount.putIfAbsent(longestBiomeString, 0);
-                        biomeCount.put(longestBiomeString, biomeCount.get(longestBiomeString) + 1);
-                    }
+                    database.executeQuery(
+                            "SELECT longest_biome FROM assembly2longestbiome WHERE assembly = '" + assembly + "'",
+                            rs -> {
+                                if (rs.next()) {
+                                    String longestBiomeString = rs.getString(1);
+                                    biomeCount.putIfAbsent(longestBiomeString, 0);
+                                    biomeCount.put(longestBiomeString, biomeCount.get(longestBiomeString) + 1);
+                                }
+                                return null;
+                            });
                 }
 
                 Map<String, Integer> pcSorted = sortMap(productCount);

--- a/src/pipeline/mgnify/GetBiomeTypes.java
+++ b/src/pipeline/mgnify/GetBiomeTypes.java
@@ -82,17 +82,12 @@ public class GetBiomeTypes {
             for(JsonValue datum : data) {
                 JsonObject analysisObj = datum.asJsonObject();
                 String analysisID = analysisObj.getString("id");
-                ResultSet resultSet = database.executeQuery("SELECT * FROM mgnify_asms WHERE assembly = '" + analysisID + "'");
-                String assemblyDB = "";
-                try {
-                    while (resultSet.next()) {
-                        assemblyDB = resultSet.getString(1);
-                    }
-                }catch (SQLException e) {
-                    e.printStackTrace();
-                }
-                if(analysisID.equals(assemblyDB)) {
-                    database.executeUpdate("INSERT INTO assembly2biome (assembly, biome) VALUES ('" + assemblyDB + "', '" +
+                boolean exists = Boolean.TRUE.equals(
+                        database.executeQuery(
+                                "SELECT 1 FROM mgnify_asms WHERE assembly = '" + analysisID + "'",
+                                rs -> rs.next()));
+                if (exists) {
+                    database.executeUpdate("INSERT INTO assembly2biome (assembly, biome) VALUES ('" + analysisID + "', '" +
                             biome.getId() + "')");
                 }
             }


### PR DESCRIPTION
## Summary
- close all JDBC statements using try-with-resources
- introduce `ResultSetHandler` functional interface
- supply helper `executeQuery` overload returning cached row sets
- update `GetBiomeTypes` and `CreateGCFTable` for new API

## Testing
- `javac $(find src -name '*.java')` *(fails: package javax.json does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68485242f1dc83338f923bfdadac82e8