### PR TITLE
Fix Antismash command list generics

### DIFF
--- a/src/pipeline/mgnify/antismash/AntismashRunner.java
+++ b/src/pipeline/mgnify/antismash/AntismashRunner.java
@@ -72,7 +72,7 @@ public class AntismashRunner implements Runnable {
                     condaEnv = "antismash7";
                 }
 
-                List commandList = new ArrayList<>();
+                List<String> commandList = new ArrayList<>();
                 commandList.add("bash");
                 commandList.add("-c");
                 commandList.add("source " + condaPath + " && conda activate " + condaEnv + " && " +


### PR DESCRIPTION
## Summary
- specify the type of the command list in `AntismashRunner`

## Testing
- `javac -Xlint:unchecked -d build /tmp/AnalyzeDatasets.java /tmp/AnalyzeDatasetsBinAC.java src/pipeline/mgnify/antismash/AntismashRunner.java`

------
https://chatgpt.com/codex/tasks/task_e_6848524445f88333bde5324f4f3a58d7